### PR TITLE
move exception getCause to TestUtils

### DIFF
--- a/src/test/scala/com/github/mmolimar/ksql/jdbc/KsqlConnectionSpec.scala
+++ b/src/test/scala/com/github/mmolimar/ksql/jdbc/KsqlConnectionSpec.scala
@@ -28,11 +28,7 @@ class KsqlConnectionSpec extends WordSpec with Matchers with MockFactory {
         reflectMethods[KsqlConnection](implementedMethods, false, ksqlConnection)
           .foreach(method => {
             assertThrows[SQLFeatureNotSupportedException] {
-              try {
                 method()
-              } catch {
-                case t: Throwable => throw t.getCause
-              }
             }
           })
       }

--- a/src/test/scala/com/github/mmolimar/ksql/jdbc/KsqlDatabaseMetaDataSpec.scala
+++ b/src/test/scala/com/github/mmolimar/ksql/jdbc/KsqlDatabaseMetaDataSpec.scala
@@ -41,11 +41,7 @@ class KsqlDatabaseMetaDataSpec extends WordSpec with Matchers with MockFactory w
         reflectMethods[KsqlDatabaseMetaData](implementedMethods, false, metadata)
           .foreach(method => {
             assertThrows[SQLFeatureNotSupportedException] {
-              try {
                 method()
-              } catch {
-                case t: Throwable => throw t.getCause
-              }
             }
           })
       }

--- a/src/test/scala/com/github/mmolimar/ksql/jdbc/KsqlStatementSpec.scala
+++ b/src/test/scala/com/github/mmolimar/ksql/jdbc/KsqlStatementSpec.scala
@@ -34,11 +34,7 @@ class KsqlStatementSpec extends WordSpec with Matchers with MockFactory with One
         reflectMethods[KsqlStatement](implementedMethods, false, statement)
           .foreach(method => {
             assertThrows[SQLFeatureNotSupportedException] {
-              try {
                 method()
-              } catch {
-                case t: Throwable => throw t.getCause
-              }
             }
           })
       }

--- a/src/test/scala/com/github/mmolimar/ksql/jdbc/resultset/KsqlResultSetSpec.scala
+++ b/src/test/scala/com/github/mmolimar/ksql/jdbc/resultset/KsqlResultSetSpec.scala
@@ -30,11 +30,7 @@ class KsqlResultSetSpec extends WordSpec with Matchers with MockFactory with One
         reflectMethods[KsqlResultSet](implementedMethods, false, resultSet)
           .foreach(method => {
             assertThrows[SQLFeatureNotSupportedException] {
-              try {
                 method()
-              } catch {
-                case t: Throwable => throw t.getCause
-              }
             }
           })
       }
@@ -134,11 +130,7 @@ class KsqlResultSetSpec extends WordSpec with Matchers with MockFactory with One
         reflectMethods[ResultSetNotSupported](Seq.empty, false, resultSet)
           .foreach(method => {
             assertThrows[SQLFeatureNotSupportedException] {
-              try {
                 method()
-              } catch {
-                case t: Throwable => throw t.getCause
-              }
             }
           })
       }

--- a/src/test/scala/com/github/mmolimar/ksql/jdbc/resultset/StaticResultSetSpec.scala
+++ b/src/test/scala/com/github/mmolimar/ksql/jdbc/resultset/StaticResultSetSpec.scala
@@ -23,11 +23,7 @@ class StaticResultSetSpec extends WordSpec with Matchers with MockFactory with O
         reflectMethods[StaticResultSet[String]](implementedMethods, false, resultSet)
           .foreach(method => {
             assertThrows[SQLFeatureNotSupportedException] {
-              try {
                 method()
-              } catch {
-                case t: Throwable => throw t.getCause
-              }
             }
           })
       }


### PR DESCRIPTION
Currently "reflectmethods" in TestUtils does not catch the InvocationTargetException. All the test using reflectmethods has to catch the InvocationTargetException and then call getCause to assert (eg. SQLFeatureNotSupportedException). Catching and returning cause from "reflectmethods" will make it possible to avoid try-catch in many tests , tests will look easy to read as well. 