### PR TITLE
add GitHub Actions

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,50 @@
+name: Build new release
+on:
+  push:
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+    - name: Determine release number
+      run: |
+        echo "release_num=$(echo ${{ github.ref }} | sed 's|.*/v||g')" >> $GITHUB_ENV
+        cat $GITHUB_ENV
+    - name: Run tests
+      run: sbt test it:test
+    - name: Build distributable jar
+      run: sbt clean assembly
+    - name: Create the release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release version ${{env.release_num}} 
+        draft: false
+        prerelease: false
+    - name: Upload .jar file to release
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ./target/scala-2.12/ksql-jdbc-driver-assembly-${{env.release_num}}.jar
+        asset_name: ksql-jdbc-driver-assembly-${{env.release_num}}.jar
+        asset_content_type: application/zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Scala CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request_target:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+    - name: Run tests
+      run: sbt test it:test


### PR DESCRIPTION
Proposal to add two new GitHub actions for the project:
- One CI action to run tests on PRs etc
- One to run tests, create a release, and attach the assembled .jar file to the release, whenever a tag is pushed up. 

This will allow people to use the driver who don't have a working `sbt` (and also doesn't require manual labor from the maintainers). 